### PR TITLE
- fixed Load to assume "" for Item attributes (and null for the Href …

### DIFF
--- a/Metadata/CXMLMetadata.cs
+++ b/Metadata/CXMLMetadata.cs
@@ -1,6 +1,6 @@
 ﻿//Project: Metadata.CXML (https://github.com/zoomicon/Metadata.CXML)
 //Filename: CXMLMetadata.cs
-//Version: 20160507
+//Version: 20160511
 
 using System;
 using System.Collections.Generic;
@@ -56,10 +56,12 @@ namespace Metadata.CXML
 
     public virtual ICXMLMetadata Load(XElement item)
     {
-      Id = item.Attribute(CXML.ATTRIB_ID).Value;
-      Title = item.Attribute(CXML.ATTRIB_NAME).Value;
-      Image = item.Attribute(CXML.ATTRIB_IMG).Value;
-      Url = new Uri(item.Attribute(CXML.ATTRIB_HREF).Value);
+      Id = item.Attribute(CXML.ATTRIB_ID)?.Value ?? "";
+      Title = item.Attribute(CXML.ATTRIB_NAME)?.Value ?? "";
+      Image = item.Attribute(CXML.ATTRIB_IMG)?.Value ?? "";
+
+      string href = item.Attribute(CXML.ATTRIB_HREF)?.Value ?? "";
+      Url = (href != "") ? new Uri(href) : null;
 
       Description = item.Element(CXML.NODE_DESCRIPTION).Value;
 

--- a/NuGet/Metadata.CXML.nuspec
+++ b/NuGet/Metadata.CXML.nuspec
@@ -4,7 +4,7 @@
 
   <metadata>
     <id>Metadata.CXML</id>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <title>Metadata.CXML</title>
     <authors>birbilis</authors>
     <owners>birbilis</owners>


### PR DESCRIPTION
…one) if they're missing
- fixed Load to set Url property to null if Item's Href equals ""
- changed NuGet package version to 1.1.0
